### PR TITLE
optimize string decoding

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -76,5 +76,3 @@ build:libc++ --define force_libcpp=enabled
 
 # Optimize build for binary size reduction.
 build:sizeopt -c opt --copt -Os
-
-

--- a/hessian2/BUILD
+++ b/hessian2/BUILD
@@ -30,6 +30,7 @@ cc_library(
 cc_library(
     name = "reader_lib",
     srcs = [
+        "reader.cc",
         "reader.hpp",
     ],
     copts = DEFAULT_COPTS,
@@ -143,5 +144,3 @@ cc_test(
         "@com_google_googletest//:gtest_main",
     ],
 )
-
-

--- a/hessian2/basic_codec/string_codec.cc
+++ b/hessian2/basic_codec/string_codec.cc
@@ -5,6 +5,21 @@ namespace Hessian2 {
 namespace {
 constexpr size_t STRING_CHUNK_SIZE = 32768;
 
+// The legal UTF-8 encoding uses 1 to 4 bytes to represent a character. Their
+// format is shown below.
+
+// length byte[0]  byte[1]  byte[2]  byte[3]
+// 1      0xxxxxxx
+// 2      110xxxxx 10xxxxxx
+// 3      1110xxxx 10xxxxxx 10xxxxxx
+// 4      11110xxx 10xxxxxx 10xxxxxx 10xxxxxx
+
+// According to the above format, only the first five bits of the first byte are
+// needed to determine the number of bytes occupied by a character. There are a
+// total of 32 possibilities for 5 bits. Use 32 possible values as indexes and
+// the corresponding number of bytes as values to form the following array to
+// speed up the parsing of UTF-8 characters.
+// Ref: https://nullprogram.com/blog/2017/10/06/
 static const size_t UTF_8_CHAR_LENGTHS[] = {1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1,
                                             1, 1, 1, 1, 1, 0, 0, 0, 0, 0, 0,
                                             0, 0, 2, 2, 2, 2, 3, 3, 4, 0};

--- a/hessian2/basic_codec/string_codec.hpp
+++ b/hessian2/basic_codec/string_codec.hpp
@@ -6,14 +6,6 @@
 
 namespace Hessian2 {
 
-bool decodeStringWithReader(std::string &out, Reader &reader);
-bool finalReadUtf8String(std::string &output, Reader &reader, size_t length);
-bool readChunkString(std::string &output, Reader &reader, size_t length,
-                     bool is_last_chunk);
-
-int64_t getUtf8StringLength(const absl::string_view &out,
-                            std::vector<uint64_t> &per_chunk_raw_size);
-
 template <>
 std::unique_ptr<std::string> Decoder::decode();
 

--- a/hessian2/reader.cc
+++ b/hessian2/reader.cc
@@ -1,0 +1,15 @@
+#include "hessian2/reader.hpp"
+
+namespace Hessian2 {
+
+template <>
+std::pair<bool, uint8_t> Reader::peek<uint8_t>(uint64_t peek_offset) {
+  uint8_t result = 0;
+  if (byteAvailable() - peek_offset < 1) {
+    return {false, 0};
+  }
+  rawReadNBytes(&result, 1, peek_offset);
+  return {true, result};
+}
+
+}  // namespace Hessian2

--- a/hessian2/reader.hpp
+++ b/hessian2/reader.hpp
@@ -56,6 +56,16 @@ class Reader {
                                     sign_extension_bits);
   }
 
+  template <>
+  std::pair<bool, uint8_t> peek<uint8_t>(uint64_t peek_offset) {
+    uint8_t result = 0;
+    if (byteAvailable() - peek_offset < 1) {
+      return {false, 0};
+    }
+    rawReadNBytes(&result, 1, peek_offset);
+    return {true, result};
+  }
+
   template <typename T, ByteOrderType Endianness = ByteOrderType::Host,
             size_t Size = sizeof(T)>
   std::pair<bool, typename std::enable_if<std::is_integral<T>::value, T>::type>

--- a/hessian2/reader.hpp
+++ b/hessian2/reader.hpp
@@ -1,5 +1,7 @@
 #pragma once
 
+#include <climits>
+#include <memory>
 #include <string>
 
 #include "byte_order.h"
@@ -56,16 +58,6 @@ class Reader {
                                     sign_extension_bits);
   }
 
-  template <>
-  std::pair<bool, uint8_t> peek<uint8_t>(uint64_t peek_offset) {
-    uint8_t result = 0;
-    if (byteAvailable() - peek_offset < 1) {
-      return {false, 0};
-    }
-    rawReadNBytes(&result, 1, peek_offset);
-    return {true, result};
-  }
-
   template <typename T, ByteOrderType Endianness = ByteOrderType::Host,
             size_t Size = sizeof(T)>
   std::pair<bool, typename std::enable_if<std::is_integral<T>::value, T>::type>
@@ -100,6 +92,9 @@ class Reader {
  protected:
   uint64_t initial_offset_{0};
 };
+
+template <>
+std::pair<bool, uint8_t> Reader::peek<uint8_t>(uint64_t peek_offset);
 
 using ReaderPtr = std::unique_ptr<Reader>;
 


### PR DESCRIPTION
Optimized the decoding process for string. Reduced memory copy overhead by reading contiguous memory. Use branch-less method to determine the length of utf-8 strings.

Since a standard benchmark is missing, I can't determine the exact performance improvement.
However, from what I've seen in practice, it has reduced the string parsing overhead significantly.