### PR TITLE
update copts.bzl and fixed a compilation error when compiling with clang

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -11,6 +11,13 @@ build --define absl=1
 build --action_env=CC
 build --action_env=CXX
 build --action_env=PATH
+build --enable_platform_specific_config
+
+# Linux
+build:linux --cxxopt=-std=c++17
+
+# windows
+build:windows --cxxopt=/std:c++17
 
 # Common flags for sanitizers
 build:sanitizer --linkopt -ldl

--- a/README.md
+++ b/README.md
@@ -241,8 +241,8 @@ Pull requests containing fixes are welcome!
 
 ### Compilers
 
-* gcc 5.0+
-* clang 5.0+
+* gcc 7.0+
+* clang 7.0+
 
 ### Build Systems
 

--- a/copts.bzl
+++ b/copts.bzl
@@ -8,15 +8,11 @@ We use the same flags as absl.
 
 load(
     "@com_google_absl//absl:copts/GENERATED_copts.bzl",
-    "ABSL_GCC_EXCEPTIONS_FLAGS",
     "ABSL_GCC_FLAGS",
     "ABSL_GCC_TEST_FLAGS",
-    "ABSL_LLVM_EXCEPTIONS_FLAGS",
     "ABSL_LLVM_FLAGS",
     "ABSL_LLVM_TEST_FLAGS",
-    "ABSL_MSVC_EXCEPTIONS_FLAGS",
     "ABSL_MSVC_FLAGS",
-    "ABSL_MSVC_LINKOPTS",
     "ABSL_MSVC_TEST_FLAGS",
 )
 
@@ -25,11 +21,11 @@ WERROR = ["-Werror=return-type", "-Werror=switch", "-Werror=sign-compare", "-Wer
 DEFAULT_COPTS = select({
     "//:windows": ABSL_MSVC_FLAGS,
     "//:llvm_compiler": ABSL_LLVM_FLAGS,
-    "//conditions:default": ABSL_GCC_FLAGS + WERROR + ["-std=c++14"],
+    "//conditions:default": ABSL_GCC_FLAGS + WERROR,
 })
 
 TEST_COPTS = DEFAULT_COPTS + select({
     "//:windows": ABSL_MSVC_TEST_FLAGS,
     "//:llvm_compiler": ABSL_LLVM_TEST_FLAGS,
-    "//conditions:default": ABSL_GCC_TEST_FLAGS + WERROR + ["-std=c++14"],
+    "//conditions:default": ABSL_GCC_TEST_FLAGS + WERROR,
 })

--- a/hessian2/string_reader.hpp
+++ b/hessian2/string_reader.hpp
@@ -1,5 +1,6 @@
 #pragma once
 
+#include "absl/base/macros.h"
 #include "absl/strings/string_view.h"
 #include "hessian2/reader.hpp"
 


### PR DESCRIPTION
* removed unsed CXX compile flags
* removed c++ standard flag in copts.bzl
* fixed a compilation error when compiling with clang
* Set the C++ standard to C++17 through .bazelrc

When trying to integrate the project into [Envoy](https://github.com/envoyproxy/envoy), because the C++ standard was set to C++14 in copts.bzl, the absl::string_view in Envoy was incompatible with the absl::string_view in the project. They are two different types.
The C++ standard should not be set in copts.bzl to avoid similar problems. 

Signed-off-by: wbpcode <comems@msn.com>