### PR TITLE
support setting the initial offset

### DIFF
--- a/hessian2/reader.hpp
+++ b/hessian2/reader.hpp
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <climits>
+#include <cstdint>
 #include <memory>
 #include <string>
 
@@ -10,7 +11,7 @@ namespace Hessian2 {
 
 class Reader {
  public:
-  Reader() = default;
+  Reader(uint64_t initial_offset = 0) : initial_offset_(initial_offset) {}
   virtual ~Reader() = default;
   // Returns the current position that has been read.
   virtual uint64_t offset() const { return initial_offset_; }


### PR DESCRIPTION
I'm not sure I have the right idea. But I think there does need to be a way to set the initial offset of the reader. This would allow us to skip parsing some content if necessary.

Signed-off-by: wbpcode <comems@msn.com>