### PR TITLE
update macro definition for windows

### DIFF
--- a/hessian2/basic_codec/date_codec.cc
+++ b/hessian2/basic_codec/date_codec.cc
@@ -2,6 +2,46 @@
 
 namespace Hessian2 {
 
+namespace {
+
+template <typename T>
+std::unique_ptr<T> readDate(ReaderPtr &reader) {
+  auto out = std::make_unique<T>();
+  uint8_t code = reader->read<uint8_t>().second;
+  switch (code) {
+    case 0x4b:
+      if (reader->byteAvailable() < 4) {
+        return nullptr;
+      }
+      return std::make_unique<T>(std::chrono::duration_cast<T>(
+          std::chrono::minutes(reader->readBE<int32_t>().second)));
+    case 0x4a:
+      if (reader->byteAvailable() < 8) {
+        return nullptr;
+      }
+      return std::make_unique<T>(std::chrono::duration_cast<T>(
+          std::chrono::milliseconds(reader->readBE<int64_t>().second)));
+  }
+  return nullptr;
+}
+
+template <typename T>
+void writeDate(WriterPtr &writer, const T &value) {
+  int64_t value_in_min =
+      std::chrono::duration_cast<std::chrono::minutes>(value).count();
+  int64_t value_in_ms =
+      std::chrono::duration_cast<std::chrono::milliseconds>(value).count();
+  if (value_in_min * 60000 == value_in_ms) {
+    writer->writeByte(0x4b);
+    writer->writeBE<int32_t>(value_in_min);
+  } else {
+    writer->writeByte(0x4a);
+    writer->writeBE<int64_t>(value_in_ms);
+  }
+}
+
+}  // namespace
+
 // # time in UTC encoded as 64-bit long milliseconds since epoch
 // ::= x4a b7 b6 b5 b4 b3 b2 b1 b0
 // ::= x4b b3 b2 b1 b0       # minutes since epoch

--- a/hessian2/basic_codec/date_codec.hpp
+++ b/hessian2/basic_codec/date_codec.hpp
@@ -8,51 +8,6 @@
 
 namespace Hessian2 {
 
-namespace {
-
-template <typename T>
-std::unique_ptr<
-    typename std::enable_if<std::chrono::__is_duration<T>::value, T>::type>
-readDate(ReaderPtr &reader) {
-  auto out = std::make_unique<T>();
-  uint8_t code = reader->read<uint8_t>().second;
-  switch (code) {
-    case 0x4b:
-      if (reader->byteAvailable() < 4) {
-        return nullptr;
-      }
-      return std::make_unique<T>(std::chrono::duration_cast<T>(
-          std::chrono::minutes(reader->readBE<int32_t>().second)));
-    case 0x4a:
-      if (reader->byteAvailable() < 8) {
-        return nullptr;
-      }
-      return std::make_unique<T>(std::chrono::duration_cast<T>(
-          std::chrono::milliseconds(reader->readBE<int64_t>().second)));
-  }
-  return nullptr;
-}
-
-template <typename T>
-void writeDate(
-    WriterPtr &writer,
-    const typename std::enable_if<std::chrono::__is_duration<T>::value, T>::type
-        &value) {
-  int64_t value_in_min =
-      std::chrono::duration_cast<std::chrono::minutes>(value).count();
-  int64_t value_in_ms =
-      std::chrono::duration_cast<std::chrono::milliseconds>(value).count();
-  if (value_in_min * 60000 == value_in_ms) {
-    writer->writeByte(0x4b);
-    writer->writeBE<int32_t>(value_in_min);
-  } else {
-    writer->writeByte(0x4a);
-    writer->writeBE<int64_t>(value_in_ms);
-  }
-}
-
-}  // namespace
-
 template <>
 std::unique_ptr<std::chrono::milliseconds> Decoder::decode();
 

--- a/hessian2/basic_codec/string_codec_unittests.cc
+++ b/hessian2/basic_codec/string_codec_unittests.cc
@@ -42,6 +42,18 @@ std::string GenerateString65536() {
   return expect;
 }
 
+std::string GenerateString131072() {
+  std::string expect;
+  for (int i = 0; i < 3072; ++i) {
+    expect.append(absl::StrFormat(
+        "%d%d%d 56789012345678901234567890123456789012345678901234567890123\n",
+        i / 100, i / 10 % 10, i % 10));
+  }
+
+  expect.resize(131072);
+  return expect;
+}
+
 std::string GenerateComplexString() {
   return "킐\u0088中国你好!\u0088\u0088\u0088\u0088\u0088\u0088";
 }
@@ -75,6 +87,22 @@ class StringCodecTest : public testing::Test {
     decodeSucc(res, data, size);
   }
 };
+
+TEST(SimpleDecodingAndEncodingTest, SimpleDecodingAndEncodingTest) {
+  {
+    std::string buffer;
+
+    std::string value = GenerateString131072();
+
+    Hessian2::Encoder encoder(buffer);
+
+    encoder.encode(value);
+
+    Hessian2::Decoder decoder(buffer);
+
+    EXPECT_EQ(*decoder.decode<std::string>(), value);
+  }
+}
 
 TEST_F(TestDecoderFramework, DecoderJavaTestCaseForString) {
   { EXPECT_TRUE(Decode<std::string>("replyString_0", std::string())); }

--- a/hessian2/byte_order.h
+++ b/hessian2/byte_order.h
@@ -23,6 +23,10 @@
 
 #elif (defined WIN32) || (defined _WIN32)
 
+// Ensure that WinSock2.h contains htonll and ntohll.
+#undef NO_EXTRA_HTON_FUNCTIONS
+#define INCL_EXTRA_HTON_FUNCTIONS
+
 #include <WinSock2.h>
 // <winsock2.h> includes <windows.h>, so undef some interfering symbols
 #undef DELETE

--- a/hessian2/byte_order.h
+++ b/hessian2/byte_order.h
@@ -21,7 +21,7 @@
 #define be32toh(x) OSSwapBigToHostInt32((x))
 #define be64toh(x) OSSwapBigToHostInt64((x))
 
-#elif WIN32
+#elif (defined WIN32) || (defined _WIN32)
 
 #include <WinSock2.h>
 // <winsock2.h> includes <windows.h>, so undef some interfering symbols

--- a/hessian2/codec.hpp
+++ b/hessian2/codec.hpp
@@ -48,7 +48,7 @@ class Decoder {
  public:
   // Error codes during decode.
   enum class ErrorCode {
-    NO_ERROR = 0,
+    NO_DECODE_ERROR,
     NOT_ENOUGH_BUFFER,
     UNEXPECTED_TYPE,
   };
@@ -87,13 +87,13 @@ class Decoder {
   std::vector<Object::RawDefinitionSharedPtr> def_ref_;
   // decode's objects need to have a lifetime longer than value_ref_
   std::vector<Object*> values_ref_;
-  ErrorCode error_code_{ErrorCode::NO_ERROR};
+  ErrorCode error_code_{ErrorCode::NO_DECODE_ERROR};
   int error_pos_{0};
 
  private:
   std::string errorCodeToString() const {
     switch (error_code_) {
-      case ErrorCode::NO_ERROR:
+      case ErrorCode::NO_DECODE_ERROR:
         return std::string();
       case ErrorCode::NOT_ENOUGH_BUFFER:
         return std::string("There is not enough buffer");
@@ -108,7 +108,7 @@ class Encoder {
  public:
   // Error codes during encode.
   enum class ErrorCode {
-    NO_ERROR = 0,
+    NO_ENCODE_ERROR,
   };
   // Use default StringWriter implement
   Encoder(std::string& output)
@@ -171,7 +171,7 @@ class Encoder {
  private:
   std::string errorCodeToString() const {
     switch (error_code_) {
-      case ErrorCode::NO_ERROR:
+      case ErrorCode::NO_ENCODE_ERROR:
         return std::string();
     }
     return std::string();
@@ -184,7 +184,7 @@ class Encoder {
   // Encode's objects need to have a lifetime longer than values_ref_
   // Only two pointers to the same object are considered references
   std::unordered_map<const Object*, uint16_t> values_ref_;
-  ErrorCode error_code_{ErrorCode::NO_ERROR};
+  ErrorCode error_code_{ErrorCode::NO_ENCODE_ERROR};
 };
 
 // fwd decl

--- a/hessian2/test_framework/process.h
+++ b/hessian2/test_framework/process.h
@@ -8,6 +8,13 @@
 
 namespace Hessian2 {
 
+#if (defined WIN32) || (defined _WIN32)
+
+#define popen _popen
+#define pclose _pclose
+
+#endif
+
 class Process {
  public:
   Process() = default;
@@ -57,5 +64,12 @@ class Process {
   std::string output_;
   bool write_mode_{false};
 };
+
+#if (defined WIN32) || (defined _WIN32)
+
+#undef popen
+#undef pclose
+
+#endif
 
 }  // namespace Hessian2


### PR DESCRIPTION
MSVC has predefined macro `_WIN32`

check: https://docs.microsoft.com/en-us/cpp/preprocessor/predefined-macros?view=msvc-160

The pr mainly made the following changes:
* update some macro definition for windows build.
* fix the bug of encoding error when the string length exceeds 2*32768.

Signed-off-by: wbpcode <comems@msn.com>