### PR TITLE
add compile_commands support to simplify development

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,17 @@
 .vscode
+.clangd
 compile_commands.json
 bazel-*
 test_hessian/.idea
 demo/bazel-*
 coverage_report/
+
+### Automatically added by Hedron's Bazel Compile Commands Extractor: https://github.com/hedronvision/bazel-compile-commands-extractor
+# Ignore the `external` link (that is added by `bazel-compile-commands-extractor`). The link differs between macOS/Linux and Windows, so it shouldn't be checked in. The pattern must not end with a trailing `/` because it's a symlink on macOS/Linux.
+/external
+# Ignore links to Bazel's output. The pattern needs the `*` because people can change the name of the directory into which your repository is cloned (changing the `bazel-<workspace_name>` symlink), and must not end with a trailing `/` because it's a symlink on macOS/Linux.
+/bazel-*
+# Ignore generated output. Although valuable (after all, the primary purpose of `bazel-compile-commands-extractor` is to produce `compile_commands.json`!), it should not be checked in.
+/compile_commands.json
+# Ignore the directory in which `clangd` stores its local index.
+/.cache/

--- a/BUILD
+++ b/BUILD
@@ -1,3 +1,5 @@
+load("@hedron_compile_commands//:refresh_compile_commands.bzl", "refresh_compile_commands")
+
 licenses(["notice"])  # Apache 2.0
 
 package(default_visibility = ["//visibility:public"])
@@ -13,5 +15,18 @@ config_setting(
     name = "windows",
     values = {
         "cpu": "x64_windows",
+    },
+)
+
+refresh_compile_commands(
+    name = "refresh_compile_commands",
+
+    # Specify the targets of interest.
+    # For example, specify a dict of targets and any flags required to build.
+    targets = {
+        "//common/...": "",
+        "//example/...": "",
+        "//hessian2/...": "",
+        "//test_hessian/...": "",
     },
 )

--- a/README.md
+++ b/README.md
@@ -269,6 +269,10 @@ contribute to this project.
 
 Happy testing!
 
+## Develop
+
+Generate `compile_commands.json` for this repo by `bazel run :refresh_compile_commands`. Thank https://github.com/hedronvision/bazel-compile-commands-extractor for it provide the great script/tool to make this so easy!
+
 ## License
 hessian2-codec is distributed under Apache License 2.0.
 

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -3,3 +3,7 @@ workspace(name = "hessian2-codec")
 load("//bazel:third_party_repositories.bzl", "load_third_party_repositories")
 
 load_third_party_repositories()
+
+load("@hedron_compile_commands//:workspace_setup.bzl", "hedron_compile_commands_setup")
+
+hedron_compile_commands_setup()

--- a/bazel/third_party_repositories.bzl
+++ b/bazel/third_party_repositories.bzl
@@ -38,3 +38,10 @@ def load_third_party_repositories():
         sha256 = "f1907a58d5e86e6c382e51441d92ad9e23aea63827ba47fd647eacc0d3a16c78",
         build_file = "//bazel/external:fmtlib.BUILD",
     )
+
+    http_archive(
+        name = "hedron_compile_commands",
+        url = "https://github.com/hedronvision/bazel-compile-commands-extractor/archive/dc36e462a2468bd79843fe5176542883b8ce4abe.tar.gz",
+        sha256 = "d63c1573eb1daa4580155a1f0445992878f4aa8c34eb165936b69504a8407662",
+        strip_prefix = "bazel-compile-commands-extractor-dc36e462a2468bd79843fe5176542883b8ce4abe",
+    )


### PR DESCRIPTION
This patch added a tool to generate compile_commands.json file. Then we can enable the auto complete, go-to-definition, etc. of clangd.

Thank https://github.com/hedronvision/bazel-compile-commands-extractor for it provide the great script/tool to make this so easy!